### PR TITLE
CI and URL updates for repo move

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The Gumbo.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2014--2015: James Porter and [other contributors](https://github.com/porterjamesj/Gumbo.jl/graphs/contributors).
+> Copyright (c) 2014--2015: James Porter and [other contributors](https://github.com/JuliaWeb/Gumbo.jl/graphs/contributors).
 >
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Gumbo.jl
 
-[![Build Status](https://travis-ci.org/porterjamesj/Gumbo.jl.svg?branch=master)](https://travis-ci.org/porterjamesj/Gumbo.jl)
-[![Build status](https://ci.appveyor.com/api/projects/status/4v6s9onnfia8mpeo)](https://ci.appveyor.com/project/porterjamesj/gumbo-jl)
+[![Build Status](https://travis-ci.org/JuliaWeb/Gumbo.jl.svg?branch=master)](https://travis-ci.org/JuliaWeb/Gumbo.jl)
+[![Build status](https://ci.appveyor.com/api/projects/status/4v6s9onnfia8mpeo)](https://ci.appveyor.com/project/JuliaWeb/gumbo-jl)
 [![Gumbo](http://pkg.julialang.org/badges/Gumbo_0.3.svg)](http://pkg.julialang.org/?pkg=Gumbo)
 [![Gumbo](http://pkg.julialang.org/badges/Gumbo_0.4.svg)](http://pkg.julialang.org/?pkg=Gumbo)
 [![Gumbo](http://pkg.julialang.org/badges/Gumbo_0.5.svg)](http://pkg.julialang.org/?pkg=Gumbo)
 [![Gumbo](http://pkg.julialang.org/badges/Gumbo_0.6.svg)](http://pkg.julialang.org/?pkg=Gumbo)
-[![codecov.io](http://codecov.io/github/porterjamesj/Gumbo.jl/coverage.svg?branch=master)](http://codecov.io/github/porterjamesj/Gumbo.jl?branch=master)
+[![codecov.io](http://codecov.io/github/JuliaWeb/Gumbo.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaWeb/Gumbo.jl?branch=master)
 
 Gumbo.jl is a Julia wrapper around
 [Google's gumbo library](https://github.com/google/gumbo-parser) for

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
 
 install:
   # Download most recent Julia Windows binary

--- a/src/manipulation.jl
+++ b/src/manipulation.jl
@@ -14,7 +14,7 @@ getattr(elem::HTMLElement, name) = elem.attributes[name]
 AbstractTrees.children(elem::HTMLElement) = elem.children
 
 # TODO there is a naming conflict here if you want to use both packages
-# (see https://github.com/porterjamesj/Gumbo.jl/issues/31)
+# (see https://github.com/JuliaWeb/Gumbo.jl/issues/31)
 #
 # I still think exporting `children` from Gumbo is the right thing to
 # do, since it's probably more common to be using this package alone


### PR DESCRIPTION
- makes all the URLs point to the right place
- updates appveyor so the build no longer fails (it used to run against nightlies, which was wrong)