### PR TITLE
option for preserving relevant whitespace in `parsehtml` 

### DIFF
--- a/src/CGumbo.jl
+++ b/src/CGumbo.jl
@@ -32,7 +32,7 @@ const DOCUMENT = Int32(0)
 const ELEMENT = Int32(1)
 const TEXT = Int32(2)
 const CDATA = Int32(3)
-const WHITESPACE = Int32(4)
+const WHITESPACE = Int32(5)
 
 struct Document
     children::Vector

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -1,6 +1,6 @@
 using Libdl
 
-function parsehtml(input::AbstractString; strict=false)
+function parsehtml(input::AbstractString; strict=false, preserve_whitespace=false)
     result_ptr = ccall((:gumbo_parse,libgumbo),
                        Ptr{CGumbo.Output},
                        (Cstring,),
@@ -10,7 +10,7 @@ function parsehtml(input::AbstractString; strict=false)
     if strict && goutput.errors.length > 0
         throw(InvalidHTMLException("input html was invalid"))
     end
-    doc = document_from_gumbo(goutput)
+    doc = document_from_gumbo(goutput, preserve_whitespace)
     gumbo_dl = Libdl.dlopen(libgumbo)
     default_options = Libdl.dlsym(gumbo_dl, :kGumboDefaultOptions)
     ccall((:gumbo_destroy_output,libgumbo),
@@ -48,34 +48,34 @@ function elem_tag(ge::CGumbo.Element)
     tag
 end
 
-function gumbo_to_jl(parent::HTMLNode, ge::CGumbo.Element)
+function gumbo_to_jl(parent::HTMLNode, ge::CGumbo.Element, preserve_whitespace)
     tag = elem_tag(ge)
     attrs = attributes(gvector_to_jl(CGumbo.Attribute,ge.attributes))
     children = HTMLNode[]
     res = HTMLElement{tag}(children, parent, attrs)
     for childptr in gvector_to_jl(CGumbo.Node{Int},ge.children)
-        node = load_node(childptr)
+        node = load_node(childptr, preserve_whitespace)
         if in(typeof(node).parameters[1], [CGumbo.Element, CGumbo.Text])
-            push!(children, gumbo_to_jl(res, node.v))
+            push!(children, gumbo_to_jl(res, node.v, preserve_whitespace))
         end
     end
     res
 end
 
 
-function gumbo_to_jl(parent::HTMLNode, gt::CGumbo.Text)
+function gumbo_to_jl(parent::HTMLNode, gt::CGumbo.Text, preserve_whitespace)
     HTMLText(parent, unsafe_string(gt.text))
 end
 
 # this is a fallback method that should only be called to construct
 # the root of a tree
-gumbo_to_jl(ge::CGumbo.Element) = gumbo_to_jl(NullNode(), ge)
+gumbo_to_jl(ge::CGumbo.Element, preserve_whitespace) = gumbo_to_jl(NullNode(), ge, preserve_whitespace)
 
 # load a GumboNode struct into memory as the appropriate Julia type
 # this involves loading it once as a CGumbo.Node{Int} in order to
 # figure out what the correct type actually is, and then reloading it as
 # that type
-function load_node(nodeptr::Ptr)
+function load_node(nodeptr::Ptr, preserve_whitespace=false)
     precursor = unsafe_load(reinterpret(Ptr{CGumbo.Node{Int}},nodeptr))
     # TODO clean this up with a Dict in the CGumbo module
     correctptr = if precursor.gntype == CGumbo.ELEMENT
@@ -84,6 +84,8 @@ function load_node(nodeptr::Ptr)
         reinterpret(Ptr{CGumbo.Node{CGumbo.Text}},nodeptr)
     elseif precursor.gntype == CGumbo.DOCUMENT
         reinterpret(Ptr{CGumbo.Node{CGumbo.Document}},nodeptr)
+    elseif preserve_whitespace && precursor.gntype == CGumbo.WHITESPACE
+        reinterpret(Ptr{CGumbo.Node{CGumbo.Text}},nodeptr)
     else
         # TODO this is super sketchy and should realistically be an
         # error
@@ -93,12 +95,12 @@ function load_node(nodeptr::Ptr)
 end
 
 # transform gumbo output into Julia data
-function document_from_gumbo(goutput::CGumbo.Output)
+function document_from_gumbo(goutput::CGumbo.Output, preserve_whitespace)
     # TODO convert some of these typeasserts to better error messages?
-    gnode::CGumbo.Node{CGumbo.Document} = load_node(goutput.document)
+    gnode::CGumbo.Node{CGumbo.Document} = load_node(goutput.document, preserve_whitespace)
     gdoc = gnode.v
     doctype = unsafe_string(gdoc.name)
-    groot::CGumbo.Node{CGumbo.Element} = load_node(goutput.root)
-    root = gumbo_to_jl(groot.v)  # already an element
+    groot::CGumbo.Node{CGumbo.Element} = load_node(goutput.root, preserve_whitespace)
+    root = gumbo_to_jl(groot.v, preserve_whitespace)  # already an element
     HTMLDocument(doctype, root)
 end

--- a/test/fixtures/whitespace_input.html
+++ b/test/fixtures/whitespace_input.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta description="test page"></meta>
+  </head>
+  <body>
+    <p>A simple test page.</p>
+    <a></a>
+    <a></a>
+    <pre>
+        <code>
+foo
+bar
+baz
+        </code>
+    </pre>
+  </body>
+</html>

--- a/test/fixtures/whitespace_output.html
+++ b/test/fixtures/whitespace_output.html
@@ -1,0 +1,16 @@
+<HTML><head>
+    <meta description="test page"></meta>
+  </head>
+  <body>
+    <p>A simple test page.</p>
+    <a></a>
+    <a></a>
+    <pre>        <code>
+foo
+bar
+baz
+        </code>
+    </pre>
+  
+
+</body></HTML>

--- a/test/io.jl
+++ b/test/io.jl
@@ -17,14 +17,15 @@ tests = [
     "30",  # regression test for issue #30
     "multitext",  # regression test for multiple HTMLText in one HTMLElement
     "varied",  # relatively complex example
+    "whitespace",  # whitespace sensitive
 ]
 for test in tests
     let
         doc = open("$testdir/fixtures/$(test)_input.html") do example
-            read(example, String) |> parsehtml
+            parsehtml(read(example, String), preserve_whitespace = test=="whitespace")
         end
         io = IOBuffer()
-        print(io, doc.root, pretty=true)
+        print(io, doc.root, pretty=test != "whitespace")
         seek(io, 0)
         @test read(io, String) ==
             read(open("$testdir/fixtures/$(test)_output.html"), String)


### PR DESCRIPTION
This is important when round-tripping HTML because whitespace *is* significant when showing it in a browser, e.g.
```
<a href="#"></a><a href="#"></a>
```
renders differently from
```
<a href="#"></a>
<a href="#"></a>
```

Printing isn't super nice since unnecessary linebreaks aren't preserved (e.g. those between two opening tags). There might be a good way to do that, but this should be good for most use cases.

Fixes https://github.com/JuliaWeb/Gumbo.jl/issues/64.