### PR TITLE
make `HTMLText` mutable

### DIFF
--- a/src/htmltypes.jl
+++ b/src/htmltypes.jl
@@ -1,6 +1,6 @@
 abstract type HTMLNode end
 
-struct HTMLText <: HTMLNode
+mutable struct HTMLText <: HTMLNode
     parent::HTMLNode
     text::AbstractString
 end


### PR DESCRIPTION
It can be useful to change a `HTMLNode`'s `parent`, but so far this only works for `HTMLElement`s.