### PR TITLE
properly escape xml entities and overhaul printing

### DIFF
--- a/src/htmltypes.jl
+++ b/src/htmltypes.jl
@@ -19,9 +19,6 @@ end
 # convenience method for defining an empty element
 HTMLElement(T::Symbol) = HTMLElement{T}(HTMLNode[],NullNode(),Dict{AbstractString,AbstractString}())
 
-element_type(::HTMLElement{T}) where {T} = T
-element_type(::Any) = Symbol("")
-
 mutable struct HTMLDocument
     doctype::AbstractString
     root::HTMLElement

--- a/src/htmltypes.jl
+++ b/src/htmltypes.jl
@@ -19,6 +19,9 @@ end
 # convenience method for defining an empty element
 HTMLElement(T::Symbol) = HTMLElement{T}(HTMLNode[],NullNode(),Dict{AbstractString,AbstractString}())
 
+element_type(::HTMLElement{T}) where {T} = T
+element_type(::Any) = Symbol("")
+
 mutable struct HTMLDocument
     doctype::AbstractString
     root::HTMLElement

--- a/src/io.jl
+++ b/src/io.jl
@@ -42,7 +42,7 @@ function substitute_attribute_entities(str)
     return str
 end
 
-function Base.print(io::IO, elem::HTMLElement{T}; pretty = false, depth = 0) where {T}
+function Base.print(io::IO, elem::HTMLElement{T}; pretty = false, depth = 0, substitution = true) where {T}
     empty_tag = T in EMPTY_TAGS
     ws_relevant = T in RELEVANT_WHITESPACE
     has_children = !isempty(elem.children)
@@ -62,7 +62,7 @@ function Base.print(io::IO, elem::HTMLElement{T}; pretty = false, depth = 0) whe
 
     if !empty_tag
         for child in elem.children
-            print(io, child; pretty = pretty_children, depth = depth + 1)
+            print(io, child; pretty = pretty_children, depth = depth + 1, substitution = substitution && !in(T, NO_ENTITY_SUBSTITUTION))
         end
 
         pretty && has_children && print(io, ' '^(2*depth))
@@ -73,8 +73,8 @@ function Base.print(io::IO, elem::HTMLElement{T}; pretty = false, depth = 0) whe
     return nothing
 end
 
-function Base.print(io::IO, node::HTMLText; pretty = false, depth = 0)
-    substitutor = element_type(node.parent) in NO_ENTITY_SUBSTITUTION ? identity : substitute_text_entities
+function Base.print(io::IO, node::HTMLText; pretty = false, depth = 0, substitution = true)
+    substitutor = substitution ? substitute_text_entities : identity
 
     if !pretty
         print(io, substitutor(node.text))

--- a/src/io.jl
+++ b/src/io.jl
@@ -74,14 +74,16 @@ function Base.print(io::IO, elem::HTMLElement{T}; pretty = false, depth = 0) whe
 end
 
 function Base.print(io::IO, node::HTMLText; pretty = false, depth = 0)
+    substitutor = element_type(node.parent) in NO_ENTITY_SUBSTITUTION ? identity : substitute_text_entities
+
     if !pretty
-        print(io, substitute_text_entities(node.text))
+        print(io, substitutor(node.text))
         return nothing
     end
 
     for line in strip.(split(node.text, '\n'))
         isempty(line) && continue
-        print(io, ' '^(2*depth), substitute_text_entities(line), '\n')
+        print(io, ' '^(2*depth), substitutor(line), '\n')
     end
 end
 

--- a/test/fixtures/varied_input.html
+++ b/test/fixtures/varied_input.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html><html><head><title>This is a title.</title><script type="text/javascript">
 alert('aaa');
-if (0 < 1) {
+if (0 < 1 && true) {
 	alert('bbb');
 }
 </script><style type="text/css">

--- a/test/fixtures/varied_output.html
+++ b/test/fixtures/varied_output.html
@@ -5,7 +5,7 @@
     </title>
     <script type="text/javascript">
 alert('aaa');
-if (0 &lt; 1) {
+if (0 < 1 && true) {
 	alert('bbb');
 }
     </script>

--- a/test/fixtures/varied_output.html
+++ b/test/fixtures/varied_output.html
@@ -4,26 +4,26 @@
       This is a title.
     </title>
     <script type="text/javascript">
-      alert('aaa');
-      if (0 < 1) {
-      	alert('bbb');
-      }
+alert('aaa');
+if (0 &lt; 1) {
+	alert('bbb');
+}
     </script>
     <style type="text/css">
-      body {font-size: 14px;}
-      h1 {
-      	font-size: 16px;
-      	font-weight: bold;
-      }
+body {font-size: 14px;}
+h1 {
+	font-size: 16px;
+	font-weight: bold;
+}
     </style>
   </head>
   <body>
     <form>
-      <input type="name" value="abc"></input>
+      <input type="name" value="abc"/>
       <p>
         AAA
-        <br></br>
-        BBB>
+        <br/>
+        BBB&gt;
       </p>
     </form>
   </body>

--- a/test/fixtures/whitespace_output.html
+++ b/test/fixtures/whitespace_output.html
@@ -1,5 +1,5 @@
 <HTML><head>
-    <meta description="test page"></meta>
+    <meta description="test page"/>
   </head>
   <body>
     <p>A simple test page.</p>

--- a/test/io.jl
+++ b/test/io.jl
@@ -19,17 +19,25 @@ tests = [
     "varied",  # relatively complex example
     "whitespace",  # whitespace sensitive
 ]
-for test in tests
+@testset for test in tests
     let
         doc = open("$testdir/fixtures/$(test)_input.html") do example
-            parsehtml(read(example, String), preserve_whitespace = test=="whitespace")
+            parsehtml(read(example, String), preserve_whitespace = (test == "whitespace"))
         end
         io = IOBuffer()
-        print(io, doc.root, pretty=test != "whitespace")
+        print(io, doc.root, pretty = (test != "whitespace"))
         seek(io, 0)
         ground_truth = read(open("$testdir/fixtures/$(test)_output.html"), String)
         # Eliminate possible line ending issues
         ground_truth = replace(ground_truth, "\r\n" => "\n")
         @test read(io, String) == ground_truth
     end
+end
+
+@testset "xml entities" begin
+    io = IOBuffer()
+
+    orig = """<p class="asd&gt;&amp;-2&quot;">&lt;faketag&gt;</p>"""
+    print(io, parsehtml(orig))
+    @test occursin(orig, String(take!(io)))
 end


### PR DESCRIPTION
This PR makes sure that we never emit unescaped xml entities (`<`, `>`, `&` in text context; additionally `"` and `'` in attributes) except in `script` or `style` tags.

The printing overhaul also simplifies the code a bit and allows us to always respect relevant whitespace (in `pre`, `textarea`, `script`, and `style` tags), no matter whether pretty printing is enabled or not. 

I've also enabled short-form printing for tags that aren't allowed to have content.

These changes are technically breaking, I think.