### PR TITLE
Adding julia compatibility to 1.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ deps/downloads
 deps/src
 deps/deps.jl
 deps/build.log
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Gumbo_jll = "528830af-5a63-567c-a44a-034ed33b8444"
 [compat]
 AbstractTrees = "0.2, 0.3"
 Gumbo_jll = "0.10"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
`platforms = supported_platforms(; experimental=true)` requires a minimum of 1.5 Julia. I'm trying build it for Macbook M1 following this bug https://github.com/JuliaWeb/Gumbo.jl/issues/90