### PR TITLE
fix: correctly handle WS in parsehtml

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -53,6 +53,7 @@ function gumbo_to_jl(parent::HTMLNode, ge::CGumbo.Element, preserve_whitespace)
     attrs = attributes(gvector_to_jl(CGumbo.Attribute,ge.attributes))
     children = HTMLNode[]
     res = HTMLElement{tag}(children, parent, attrs)
+    preserve_whitespace = tag in RELEVANT_WHITESPACE || preserve_whitespace
     for childptr in gvector_to_jl(CGumbo.Node{Int},ge.children)
         node = load_node(childptr, preserve_whitespace)
         if in(typeof(node).parameters[1], [CGumbo.Element, CGumbo.Text])

--- a/test/fixtures/whitespace2_input.html
+++ b/test/fixtures/whitespace2_input.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta description="test page"></meta>
+  </head>
+  <body>
+    <p>A simple test page.</p>
+    <a></a>
+    <a></a>
+    <pre>
+        <code>
+foo
+bar
+baz
+        </code>
+    </pre>
+  </body>
+</html>

--- a/test/fixtures/whitespace2_output.html
+++ b/test/fixtures/whitespace2_output.html
@@ -1,0 +1,18 @@
+<HTML>
+  <head>
+    <meta description="test page"/>
+  </head>
+  <body>
+    <p>
+      A simple test page.
+    </p>
+    <a></a>
+    <a></a>
+    <pre>        <code>
+foo
+bar
+baz
+        </code>
+        </pre>
+  </body>
+</HTML>

--- a/test/io.jl
+++ b/test/io.jl
@@ -18,6 +18,7 @@ tests = [
     "multitext",  # regression test for multiple HTMLText in one HTMLElement
     "varied",  # relatively complex example
     "whitespace",  # whitespace sensitive
+    "whitespace2",  # whitespace sensitive
 ]
 @testset for test in tests
     let


### PR DESCRIPTION
even when `preserve_whitespace=false`.