### PR TITLE
add parsing option preserve_template

### DIFF
--- a/src/CGumbo.jl
+++ b/src/CGumbo.jl
@@ -33,6 +33,7 @@ const ELEMENT = Int32(1)
 const TEXT = Int32(2)
 const CDATA = Int32(3)
 const WHITESPACE = Int32(5)
+const TEMPLATE = Int32(6)
 
 struct Document
     children::Vector

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -1,6 +1,6 @@
 using Libdl
 
-function parsehtml(input::AbstractString; strict=false, preserve_whitespace=false)
+function parsehtml(input::AbstractString; strict=false, preserve_whitespace=false, preserve_template=false)
     result_ptr = ccall((:gumbo_parse,libgumbo),
                        Ptr{CGumbo.Output},
                        (Cstring,),
@@ -10,7 +10,7 @@ function parsehtml(input::AbstractString; strict=false, preserve_whitespace=fals
     if strict && goutput.errors.length > 0
         throw(InvalidHTMLException("input html was invalid"))
     end
-    doc = document_from_gumbo(goutput, preserve_whitespace)
+    doc = document_from_gumbo(goutput, preserve_whitespace, preserve_template)
     default_options = Libdl.dlsym(Gumbo_jll.libgumbo_handle, :kGumboDefaultOptions)
 
     ccall((:gumbo_destroy_output,libgumbo),
@@ -48,38 +48,38 @@ function elem_tag(ge::CGumbo.Element)
     tag
 end
 
-function gumbo_to_jl(parent::HTMLNode, ge::CGumbo.Element, preserve_whitespace)
+function gumbo_to_jl(parent::HTMLNode, ge::CGumbo.Element, preserve_whitespace, preserve_template)
     tag = elem_tag(ge)
     attrs = attributes(gvector_to_jl(CGumbo.Attribute,ge.attributes))
     children = HTMLNode[]
     res = HTMLElement{tag}(children, parent, attrs)
     preserve_whitespace = tag in RELEVANT_WHITESPACE || preserve_whitespace
     for childptr in gvector_to_jl(CGumbo.Node{Int},ge.children)
-        node = load_node(childptr, preserve_whitespace)
+        node = load_node(childptr, preserve_whitespace, preserve_template)
         if in(typeof(node).parameters[1], [CGumbo.Element, CGumbo.Text])
-            push!(children, gumbo_to_jl(res, node.v, preserve_whitespace))
+            push!(children, gumbo_to_jl(res, node.v, preserve_whitespace, preserve_template))
         end
     end
     res
 end
 
 
-function gumbo_to_jl(parent::HTMLNode, gt::CGumbo.Text, preserve_whitespace)
+function gumbo_to_jl(parent::HTMLNode, gt::CGumbo.Text, preserve_whitespace, preserve_template)
     HTMLText(parent, unsafe_string(gt.text))
 end
 
 # this is a fallback method that should only be called to construct
 # the root of a tree
-gumbo_to_jl(ge::CGumbo.Element, preserve_whitespace) = gumbo_to_jl(NullNode(), ge, preserve_whitespace)
+gumbo_to_jl(ge::CGumbo.Element, preserve_whitespace, preserve_template) = gumbo_to_jl(NullNode(), ge, preserve_whitespace, preserve_template)
 
 # load a GumboNode struct into memory as the appropriate Julia type
 # this involves loading it once as a CGumbo.Node{Int} in order to
 # figure out what the correct type actually is, and then reloading it as
 # that type
-function load_node(nodeptr::Ptr, preserve_whitespace=false)
+function load_node(nodeptr::Ptr, preserve_whitespace=false, preserve_template=false)
     precursor = unsafe_load(reinterpret(Ptr{CGumbo.Node{Int}},nodeptr))
     # TODO clean this up with a Dict in the CGumbo module
-    correctptr = if precursor.gntype == CGumbo.ELEMENT
+    correctptr = if precursor.gntype == CGumbo.ELEMENT || preserve_template && precursor.gntype == CGumbo.TEMPLATE
         reinterpret(Ptr{CGumbo.Node{CGumbo.Element}},nodeptr)
     elseif precursor.gntype == CGumbo.TEXT
         reinterpret(Ptr{CGumbo.Node{CGumbo.Text}},nodeptr)
@@ -96,12 +96,12 @@ function load_node(nodeptr::Ptr, preserve_whitespace=false)
 end
 
 # transform gumbo output into Julia data
-function document_from_gumbo(goutput::CGumbo.Output, preserve_whitespace)
+function document_from_gumbo(goutput::CGumbo.Output, preserve_whitespace, preserve_template)
     # TODO convert some of these typeasserts to better error messages?
-    gnode::CGumbo.Node{CGumbo.Document} = load_node(goutput.document, preserve_whitespace)
+    gnode::CGumbo.Node{CGumbo.Document} = load_node(goutput.document, preserve_whitespace, preserve_template)
     gdoc = gnode.v
     doctype = unsafe_string(gdoc.name)
-    groot::CGumbo.Node{CGumbo.Element} = load_node(goutput.root, preserve_whitespace)
-    root = gumbo_to_jl(groot.v, preserve_whitespace)  # already an element
+    groot::CGumbo.Node{CGumbo.Element} = load_node(goutput.root, preserve_whitespace, preserve_template)
+    root = gumbo_to_jl(groot.v, preserve_whitespace, preserve_template)  # already an element
     HTMLDocument(doctype, root)
 end

--- a/test/fixtures/template_input.html
+++ b/test/fixtures/template_input.html
@@ -1,0 +1,3 @@
+<template v-slot:avatar>
+    <q-icn name='moo' />
+</template>

--- a/test/fixtures/template_output.html
+++ b/test/fixtures/template_output.html
@@ -1,0 +1,8 @@
+<HTML>
+  <head>
+    <template v-slot:avatar="">
+      <q-icn name="moo"></q-icn>
+    </template>
+  </head>
+  <body></body>
+</HTML>

--- a/test/io.jl
+++ b/test/io.jl
@@ -19,11 +19,12 @@ tests = [
     "varied",  # relatively complex example
     "whitespace",  # whitespace sensitive
     "whitespace2",  # whitespace sensitive
+    "template",  # preserve template
 ]
 @testset for test in tests
     let
         doc = open("$testdir/fixtures/$(test)_input.html") do example
-            parsehtml(read(example, String), preserve_whitespace = (test == "whitespace"))
+            parsehtml(read(example, String), preserve_whitespace = (test == "whitespace"), preserve_template = (test == "template"))
         end
         io = IOBuffer()
         print(io, doc.root, pretty = (test != "whitespace"))


### PR DESCRIPTION
This is a PR to fix #86 
```julia
julia> parsehtml("<template v-slot:avatar><q-icn name='moo' /></template>", preserve_template = true)
HTML Document:
<!DOCTYPE >
HTMLElement{:HTML}:<HTML>
  <head>
    <template v-slot:avatar="">
      <q-icn name="moo"></q-icn>
    </template>
  </head>
  <body></body>
</HTML>
```
Tests are added and pass.